### PR TITLE
Create personal schedule planner layout

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,0 +1,53 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Personal Schedule</title>
+  <link rel="stylesheet" href="styles.css">
+</head>
+<body>
+  <main class="planner">
+    <header class="planner__header">
+      <h1>Personal Schedule</h1>
+      <p class="planner__subtitle">Plan your day, one page at a time.</p>
+    </header>
+
+    <section class="planner__grid" aria-label="Daily planning layout">
+      <div class="stack-column">
+        <article class="panel notes">
+          <h2 id="notes-heading">Notes</h2>
+          <textarea aria-labelledby="notes-heading" placeholder="Jot down quick notes, meeting details, or ideas."></textarea>
+        </article>
+
+        <article class="panel brain-dump">
+          <h2 id="brain-dump-heading">Brain Dump</h2>
+          <textarea aria-labelledby="brain-dump-heading" placeholder="Capture thoughts, reminders, and anything on your mind."></textarea>
+        </article>
+      </div>
+
+      <div class="grid-column">
+        <article class="panel schedule">
+          <h2 id="schedule-heading">Schedule</h2>
+          <textarea aria-labelledby="schedule-heading" placeholder="Map out your appointments, time blocks, and daily flow."></textarea>
+        </article>
+
+        <article class="panel todo">
+          <h2 id="todo-heading">To Do</h2>
+          <textarea aria-labelledby="todo-heading" placeholder="Top priorities that must get done today."></textarea>
+        </article>
+
+        <article class="panel could-do">
+          <h2 id="could-do-heading">Could Do</h2>
+          <textarea aria-labelledby="could-do-heading" placeholder="Nice-to-have tasks if time allows."></textarea>
+        </article>
+
+        <article class="panel reminders">
+          <h2 id="reminders-heading">Reminders</h2>
+          <textarea aria-labelledby="reminders-heading" placeholder="Important follow-ups, calls, or deadlines."></textarea>
+        </article>
+      </div>
+    </section>
+  </main>
+</body>
+</html>

--- a/styles.css
+++ b/styles.css
@@ -1,0 +1,218 @@
+:root {
+  color-scheme: light;
+  --page-bg: #eef1f7;
+  --paper-bg: #ffffff;
+  --panel-border: #1f2933;
+  --panel-shadow: rgba(15, 23, 42, 0.08);
+  --text-primary: #111827;
+  --text-muted: #64748b;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  font-family: "Inter", "Segoe UI", "Helvetica Neue", Arial, sans-serif;
+  background: var(--page-bg);
+  color: var(--text-primary);
+}
+
+.planner {
+  max-width: 1120px;
+  margin: 3.5rem auto;
+  padding: 2.5rem 2.25rem 3rem;
+  background: var(--paper-bg);
+  border-radius: 28px;
+  box-shadow: 0 30px 60px var(--panel-shadow);
+  display: flex;
+  flex-direction: column;
+  gap: 2.75rem;
+}
+
+.planner__header h1 {
+  margin: 0;
+  font-size: 2.4rem;
+  letter-spacing: 0.04em;
+}
+
+.planner__subtitle {
+  margin: 0.35rem 0 0;
+  font-size: 1rem;
+  color: var(--text-muted);
+}
+
+.planner__grid {
+  display: grid;
+  grid-template-columns: minmax(0, 0.92fr) minmax(0, 1.08fr);
+  gap: 2.25rem;
+}
+
+.stack-column {
+  display: flex;
+  flex-direction: column;
+  gap: 1.85rem;
+}
+
+.grid-column {
+  display: grid;
+  gap: 1.85rem;
+  grid-template-columns: minmax(0, 1.15fr) minmax(0, 1.15fr) minmax(0, 0.7fr);
+  grid-template-rows: auto auto;
+}
+
+.panel {
+  background: var(--paper-bg);
+  border: 2px solid var(--panel-border);
+  border-radius: 22px;
+  padding: 1.35rem 1.4rem;
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+  min-height: 180px;
+}
+
+.panel h2 {
+  margin: 0;
+  font-size: 1.1rem;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+}
+
+.panel textarea {
+  flex: 1;
+  min-height: 140px;
+  border: none;
+  resize: none;
+  background: transparent;
+  font: inherit;
+  font-size: 1rem;
+  color: var(--text-primary);
+  line-height: 1.6;
+  padding: 0.35rem 0.5rem;
+  border-radius: 12px;
+  transition: box-shadow 0.2s ease;
+}
+
+.panel textarea::placeholder {
+  color: var(--text-muted);
+}
+
+.panel textarea:focus {
+  outline: none;
+  box-shadow: 0 0 0 2px rgba(99, 102, 241, 0.45);
+}
+
+.schedule {
+  grid-column: 1 / -1;
+  min-height: 340px;
+}
+
+.notes {
+  min-height: 240px;
+}
+
+.brain-dump {
+  min-height: 280px;
+}
+
+.todo,
+.could-do {
+  min-height: 200px;
+}
+
+.reminders {
+  grid-column: 3 / 4;
+  grid-row: 2 / 3;
+  min-height: 200px;
+  flex-direction: row;
+  align-items: stretch;
+  justify-content: center;
+  gap: 1.2rem;
+}
+
+.reminders h2 {
+  writing-mode: vertical-rl;
+  transform: rotate(180deg);
+  letter-spacing: 0.18em;
+  font-size: 1rem;
+  text-align: center;
+  align-self: center;
+}
+
+.reminders textarea {
+  min-height: 180px;
+}
+
+@media (max-width: 1100px) {
+  .planner {
+    margin: 2.5rem 1.5rem;
+    padding: 2rem 1.75rem 2.5rem;
+  }
+
+  .planner__grid {
+    grid-template-columns: 1fr;
+  }
+
+  .grid-column {
+    grid-template-columns: 1fr 1fr;
+    grid-template-rows: auto auto auto;
+  }
+
+  .reminders {
+    grid-column: 1 / -1;
+    flex-direction: column;
+    align-items: flex-start;
+  }
+
+  .reminders h2 {
+    writing-mode: horizontal-tb;
+    transform: none;
+  }
+}
+
+@media (max-width: 768px) {
+  .planner {
+    margin: 1.75rem 1rem;
+    padding: 1.75rem 1.25rem 2.25rem;
+  }
+
+  .grid-column {
+    grid-template-columns: 1fr;
+  }
+
+  .schedule,
+  .reminders,
+  .todo,
+  .could-do {
+    grid-column: 1 / -1;
+  }
+
+  .reminders {
+    flex-direction: column;
+    gap: 0.75rem;
+  }
+}
+
+@media print {
+  body {
+    background: #ffffff;
+  }
+
+  .planner {
+    margin: 0;
+    border-radius: 0;
+    box-shadow: none;
+    padding: 1.5rem 1.25rem 2rem;
+  }
+
+  .panel {
+    box-shadow: none;
+  }
+
+  textarea {
+    -webkit-print-color-adjust: exact;
+    print-color-adjust: exact;
+  }
+}


### PR DESCRIPTION
## Summary
- add a standalone HTML page that lays out schedule, notes, brain dump, to-do, could-do, and reminders sections
- style the planner to mirror the requested arrangement with responsive grid sizing and vertical reminders label
- include text areas with focus styling plus print-friendly settings for easier digital or physical use

## Testing
- not run (static content)


------
https://chatgpt.com/codex/tasks/task_e_68d08b4664ec832d9c31b617fb8aae30